### PR TITLE
Call this script from continue.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ The battery usage is roughly 3-4% per hour (no upload, running on WIFI) with thi
 
 Installation
 ======
-Place this script in /data/data/com.termux/files/ and add this line to /data/data/com.termux/files/continue.sh right after ```#!/usr/bin/bash```:
+Place this script in:
+```
+/data/data/com.termux/files/
+```
+and add this line to ```/data/data/com.termux/files/continue.sh``` right after ```#!/usr/bin/bash```:
 
 ```
 /system/bin/sh /data/data/com.termux/files/battery_saver.sh &

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The battery usage is roughly 3-4% per hour (no upload, running on WIFI) with thi
 
 Installation
 ======
-Place this script in /data/openpilot/ and add this line to launch_openpilot.sh right after ```#!/usr/bin/bash```:
+Place this script in /data/data/com.termux/files/ and add this line to /data/data/com.termux/files/continue.sh right after ```#!/usr/bin/bash```:
 
 ```
-/system/bin/sh ./battery_saver.sh &
+/system/bin/sh /data/data/com.termux/files/battery_saver.sh &
 ```
 
 Then reboot your EON.


### PR DESCRIPTION
If you add this to continue.sh script, it doesn't need to be in /data/openpilot and won't interfere with openpilot updates or need to be re-added after an update.

These are some nice optimizations. Why not open as a PR directly to openpilot?
